### PR TITLE
Fix arithmetic bug in destructive pack and send

### DIFF
--- a/ElasticFrameProtocol.h
+++ b/ElasticFrameProtocol.h
@@ -284,7 +284,7 @@ public:
      * @return ElasticFrameMessages
      */
     ElasticFrameMessages
-    destructivePackAndSendFromPtr(const uint8_t *pPacket, size_t lPacketSize, ElasticFrameContent lDataContent, uint64_t lPts,
+    destructivePackAndSendFromPtr(uint8_t *pPacket, size_t lPacketSize, ElasticFrameContent lDataContent, uint64_t lPts,
                        uint64_t lDts, uint32_t lCode, uint8_t lStreamID, uint8_t lFlags,
                                   const std::function<void(const uint8_t*, size_t)>& rSendFunction);
 

--- a/unitTests/UnitTest21.cpp
+++ b/unitTests/UnitTest21.cpp
@@ -73,7 +73,7 @@ bool UnitTest21::startUnitTest() {
         //destructivePackAndSendFromPtr(const uint8_t *pPacket, size_t lPacketSize, ElasticFrameContent lDataContent, uint64_t lPts,
         //        uint64_t lDts, uint32_t lCode, uint8_t lStreamID, uint8_t lFlags, lambda);
 
-        result = myEFPPacker->destructivePackAndSendFromPtr((const uint8_t*)mydata.data()+100, mydata.size()-100, ElasticFrameContent::h264, packetNumber + 1001, packetNumber + 1, 0,
+        result = myEFPPacker->destructivePackAndSendFromPtr(mydata.data()+100, mydata.size()-100, ElasticFrameContent::h264, packetNumber + 1001, packetNumber + 1, 0,
                                                             streamID, NO_FLAGS, [&](const uint8_t* lData, size_t lSize) {
                     ElasticFrameMessages info = myEFPReciever->receiveFragmentFromPtr(lData, lSize, 0);
                     if (info != ElasticFrameMessages::noError) {


### PR DESCRIPTION
While rewriting the unit tests to the GTest suite, I discovered this bug which was, for some reason, not triggered by the current unit test implementation. In the current implementation, the offsets of the subpackets are calculated incorrectly, as the precedence order of operators in C++ says C-style cast has a higher precedence than the arithmetic operators. This results in that the pointers are not offset in steps of bytes as intended, but in steps of the size of the struct we are casting them to. Changed the casts to C++-style reinterpret_cast instead, which solves the precedence order.

Also changed the definition of the function to take a non-const pointer to the data, as the function will actually make changes to the data, violating the const-ness.

A unit test for this will be pushed in another PR.