### PR TITLE
Fix typo in C and Golang API

### DIFF
--- a/ElasticFrameProtocol.cpp
+++ b/ElasticFrameProtocol.cpp
@@ -32,8 +32,8 @@ ElasticFrameProtocolReceiver::ElasticFrameProtocolReceiver(uint32_t lBucketTimeo
     mBucketList = new Bucket[CIRCULAR_BUFFER_SIZE + 1];
 
     mCTX = std::move(pCTX);
-    c_recieveCallback = nullptr;
-    c_recieveEmbeddedDataCallback = nullptr;
+    c_receiveCallback = nullptr;
+    c_receiveEmbeddedDataCallback = nullptr;
     receiveCallback = std::bind(&ElasticFrameProtocolReceiver::gotData, this, std::placeholders::_1,
                                 std::placeholders::_2);
 
@@ -66,9 +66,9 @@ ElasticFrameProtocolReceiver::~ElasticFrameProtocolReceiver() {
 // C API callback. Dummy callback if C++
 void ElasticFrameProtocolReceiver::gotData(ElasticFrameProtocolReceiver::pFramePtr &rPacket,
                                            ElasticFrameProtocolContext *pCTX) {
-    if (c_recieveCallback) {
+    if (c_receiveCallback) {
         size_t payloadDataPosition = 0;
-        if (c_recieveEmbeddedDataCallback && (rPacket->mFlags & (uint8_t) INLINE_PAYLOAD) && !rPacket->mBroken) {
+        if (c_receiveEmbeddedDataCallback && (rPacket->mFlags & (uint8_t) INLINE_PAYLOAD) && !rPacket->mBroken) {
             std::vector<std::vector<uint8_t>> embeddedData;
             std::vector<uint8_t> embeddedContentFlag;
 
@@ -80,7 +80,7 @@ void ElasticFrameProtocolReceiver::gotData(ElasticFrameProtocolReceiver::pFrameP
                 return;
             }
             for (int x = 0; x < embeddedData.size(); x++) {
-                c_recieveEmbeddedDataCallback(embeddedData[x].data(), embeddedData[x].size(), embeddedContentFlag[x],
+                c_receiveEmbeddedDataCallback(embeddedData[x].data(), embeddedData[x].size(), embeddedContentFlag[x],
                                               rPacket->mPts, mCTX->mUnsafePointer);
             }
             //Adjust the pointers for the payload callback
@@ -89,7 +89,7 @@ void ElasticFrameProtocolReceiver::gotData(ElasticFrameProtocolReceiver::pFrameP
                 return;
             }
         }
-        c_recieveCallback(rPacket->pFrameData + payloadDataPosition, //compensate for the embedded data
+        c_receiveCallback(rPacket->pFrameData + payloadDataPosition, //compensate for the embedded data
                           rPacket->mFrameSize - payloadDataPosition, //compensate for the embedded data
                           rPacket->mDataContent,
                           (uint8_t) rPacket->mBroken,
@@ -1306,8 +1306,8 @@ uint64_t efp_init_receive(uint32_t bucketTimeout,
     if (!result.first->second) {
         return 0;
     }
-    result.first->second->c_recieveCallback = f;
-    result.first->second->c_recieveEmbeddedDataCallback = g;
+    result.first->second->c_receiveCallback = f;
+    result.first->second->c_receiveEmbeddedDataCallback = g;
     c_object_handle++;
     return local_c_object_handle;
 }

--- a/ElasticFrameProtocol.h
+++ b/ElasticFrameProtocol.h
@@ -480,7 +480,7 @@ public:
     std::function<void(pFramePtr &rPacket, ElasticFrameProtocolContext* pCTX)> receiveCallback = nullptr;
 
     /**
-    * Recieve data callback (C-API version)
+    * receive data callback (C-API version)
     *
     * @param pData Pointer to the data.
     * @param lSize Size of the data.
@@ -494,7 +494,7 @@ public:
     * @param lFlags signal what flags are used
     * @param lCtx context
     */
-    void (*c_recieveCallback)(uint8_t *pData,
+    void (*c_receiveCallback)(uint8_t *pData,
                               size_t lSize,
                               uint8_t lData_content,
                               uint8_t lBroken,
@@ -511,7 +511,7 @@ public:
     *
     * If the EFP frame is broken this C-callback will not be triggered since the data integrity is unknown,
     * there will be no attempt to extraxt any embedded data.
-    * c_recieveCallback will be triggered with broken set (meaning != 0) and if any embedded data
+    * c_receiveCallback will be triggered with broken set (meaning != 0) and if any embedded data
     * (flags & INLINE_PAYLOAD) it will be in the preamble of the broken EFP-Frame. You may try to
     * extract the data manually.
     *
@@ -521,7 +521,7 @@ public:
     * @param lPts PTS of the frame (Can be used to associate with a EFP frame).
     * @param lCtx context
     */
-    void (*c_recieveEmbeddedDataCallback)(uint8_t *pData,
+    void (*c_receiveEmbeddedDataCallback)(uint8_t *pData,
                                           size_t lSize,
                                           uint8_t lData_type,
                                           uint64_t lPts,
@@ -588,7 +588,7 @@ private:
 
     //Private methods ----- START ------
 
-    // Stop the reciever worker
+    // Stop the receiver worker
     ElasticFrameMessages stopReceiver();
 
     // C-API callback. If C++ is used this is a dummy callback

--- a/efp_c_api/main.c
+++ b/efp_c_api/main.c
@@ -113,14 +113,14 @@ int main() {
     }
     printf("Sender created.\n");
 
-    //EFP Recieve
-    printf("Create reciever.\n");
+    //EFP receive
+    printf("Create receiver.\n");
     efp_object_handle_receive = efp_init_receive(30, 10, &receive_data_callback, &receive_embedded_data_callback, context, EFP_MODE_THREAD);
     if (!efp_object_handle_receive) {
-        printf("Fatal. Failed creating EFP reciever");
+        printf("Fatal. Failed creating EFP receiver");
         return 1;
     }
-    printf("Reciever created.\n");
+    printf("receiver created.\n");
 
     //Prepare data
     for (int x = 0; x < TEST_DATA_SIZE; x++) {

--- a/efp_golang/efp_api.go
+++ b/efp_golang/efp_api.go
@@ -28,7 +28,7 @@ uint64_t initEFPSender(uint64_t mtu, void* ctx) {
 }
 
 //init receiver
-uint64_t initEFPReciever(uint32_t bucketTimeout, uint32_t holTimeout, void* ctx, uint32_t mode) {
+uint64_t initEFPReceiver(uint32_t bucketTimeout, uint32_t holTimeout, void* ctx, uint32_t mode) {
 	return efp_init_receive(bucketTimeout, holTimeout, &gotDataEFP, &gotEmbeddedDataEFP, ctx, mode);
 }
 */

--- a/efp_golang/efp_golang.go
+++ b/efp_golang/efp_golang.go
@@ -8,7 +8,7 @@ package main
 #include <stdint.h>
 #include "elastic_frame_protocol_c_api.h"
 uint64_t initEFPSender(uint64_t mtu, void* ctx);
-uint64_t initEFPReciever(uint32_t bucketTimeout, uint32_t holTimeout, void* ctx, uint32_t mode);
+uint64_t initEFPReceiver(uint32_t bucketTimeout, uint32_t holTimeout, void* ctx, uint32_t mode);
 */
 import "C"
 import (
@@ -37,8 +37,8 @@ func main() {
 	//Init a EFP sender MTU 300 bytes
 	efpSendID := C.initEFPSender(300, nil)
 
-	//Start a EFP reciever (bucket time-out 100ms, HOL timeout 50ms, context == nil and the mode is threaded)
-	efpReceiveID = C.initEFPReciever(100, 50, nil, C.EFP_MODE_THREAD)
+	//Start a EFP receiver (bucket time-out 100ms, HOL timeout 50ms, context == nil and the mode is threaded)
+	efpReceiveID = C.initEFPReceiver(100, 50, nil, C.EFP_MODE_THREAD)
 
 	//Create a data block containing a null terminated string"
 	stringtoEmbed := append([]byte("Embed this string"), byte(0))
@@ -112,18 +112,18 @@ func gotDataEFP(data *C.uchar,
 	testsComplete := true
 
 	if broken != 0 {
-		fmt.Printf("Recieved frame is broken. \n")
+		fmt.Printf("received frame is broken. \n")
 		testsComplete = false
 	}
 
 	if size != testSetSize {
-		fmt.Printf("Recieved frame size missmatch. \n")
+		fmt.Printf("received frame size missmatch. \n")
 		testsComplete = false
 	}
 
 	for i := 0; i < testSetSize; i++ {
 		if thisData[i] != uint8(i) {
-			fmt.Printf("Recieved frame data not correct. \n")
+			fmt.Printf("received frame data not correct. \n")
 			testsComplete = false
 		}
 	}


### PR DESCRIPTION
Fix type `recieve` -> `receive` in C and Golang APIs.