### PR TITLE
Propagate the super frame counter to the receiver callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(runUnitTestsEFP
         ${CMAKE_CURRENT_SOURCE_DIR}/unitTests/UnitTest20.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/unitTests/UnitTest21.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/unitTests/UnitTest22.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/unitTests/UnitTest23.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/unitTests/UnitTestHelpers.cpp
         )
 

--- a/ElasticFrameProtocol.cpp
+++ b/ElasticFrameProtocol.cpp
@@ -463,6 +463,7 @@ void ElasticFrameProtocolReceiver::runToCompletionMethod(
                 rBucket.second->mBucketData->mStreamID = rBucket.second->mStream;
                 rBucket.second->mBucketData->mSource = rBucket.second->mSource;
                 rBucket.second->mBucketData->mFlags = rBucket.second->mFlags;
+                rBucket.second->mBucketData->mSuperFrameNo = rBucket.second->mSavedSuperFrameNo;
                 if (rReceiveFunction) {
                     rReceiveFunction(rBucket.second->mBucketData, mCTX ? mCTX.get() : nullptr);
                 } else {
@@ -484,6 +485,7 @@ void ElasticFrameProtocolReceiver::runToCompletionMethod(
                 rBucket.second->mBucketData->mStreamID = rBucket.second->mStream;
                 rBucket.second->mBucketData->mSource = rBucket.second->mSource;
                 rBucket.second->mBucketData->mFlags = rBucket.second->mFlags;
+                rBucket.second->mBucketData->mSuperFrameNo = rBucket.second->mSavedSuperFrameNo;
                 if (rReceiveFunction) {
                     rReceiveFunction(rBucket.second->mBucketData, mCTX ? mCTX.get() : nullptr);
                 } else {
@@ -512,6 +514,7 @@ void ElasticFrameProtocolReceiver::runToCompletionMethod(
                 rBucket.second->mBucketData->mStreamID = rBucket.second->mStream;
                 rBucket.second->mBucketData->mSource = rBucket.second->mSource;
                 rBucket.second->mBucketData->mFlags = rBucket.second->mFlags;
+                rBucket.second->mBucketData->mSuperFrameNo = rBucket.second->mSavedSuperFrameNo;
                 if (rReceiveFunction) {
                     rReceiveFunction(rBucket.second->mBucketData, mCTX ? mCTX.get() : nullptr);
                 } else {
@@ -651,6 +654,7 @@ void ElasticFrameProtocolReceiver::receiverWorker() {
                         rBucket.second->mBucketData->mStreamID = rBucket.second->mStream;
                         rBucket.second->mBucketData->mSource = rBucket.second->mSource;
                         rBucket.second->mBucketData->mFlags = rBucket.second->mFlags;
+                        rBucket.second->mBucketData->mSuperFrameNo = rBucket.second->mSavedSuperFrameNo;
                         mSuperFrameQueue.push_back(std::move(rBucket.second->mBucketData));
                         mSuperFrameReady = true;
                     }
@@ -672,6 +676,7 @@ void ElasticFrameProtocolReceiver::receiverWorker() {
                         rBucket.second->mBucketData->mStreamID = rBucket.second->mStream;
                         rBucket.second->mBucketData->mSource = rBucket.second->mSource;
                         rBucket.second->mBucketData->mFlags = rBucket.second->mFlags;
+                        rBucket.second->mBucketData->mSuperFrameNo = rBucket.second->mSavedSuperFrameNo;
                         mSuperFrameQueue.push_back(std::move(rBucket.second->mBucketData));
                         mSuperFrameReady = true;
                     }
@@ -700,6 +705,7 @@ void ElasticFrameProtocolReceiver::receiverWorker() {
                         rBucket.second->mBucketData->mStreamID = rBucket.second->mStream;
                         rBucket.second->mBucketData->mSource = rBucket.second->mSource;
                         rBucket.second->mBucketData->mFlags = rBucket.second->mFlags;
+                        rBucket.second->mBucketData->mSuperFrameNo = rBucket.second->mSavedSuperFrameNo;
                         mSuperFrameQueue.push_back(std::move(rBucket.second->mBucketData));
                         mSuperFrameReady = true;
                     }

--- a/ElasticFrameProtocol.h
+++ b/ElasticFrameProtocol.h
@@ -396,6 +396,7 @@ public:
         uint8_t mStreamID = 0;           // A streamID used for stream separation of same content type (if you got more than one H264 streams for example)
         uint8_t mSource = 0;             // A transparent value 'passed by' the receivedFragment method to separate multiple parallel EFP streams
         uint8_t mFlags = NO_FLAGS;       // Flags used by the frame
+        uint16_t mSuperFrameNo = 0;      // The 16 bit super frame counter. Useful for calculating the number of lost frames in HOL mode
 
         SuperFrame(const SuperFrame &) = delete;
 

--- a/unitTests/UnitTest10.cpp
+++ b/unitTests/UnitTest10.cpp
@@ -9,6 +9,7 @@
 //UnitTest10
 //send two type 2 packets out of order and receive them in order.
 TEST(UnitTest10, SendType2FragmentsAndSwapOrder) {
+    const size_t FRAME_SIZE = (MTU - ElasticFrameProtocolSender::getType2Size());
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50,
                                                                                                                  20);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -49,11 +50,11 @@ TEST(UnitTest10, SendType2FragmentsAndSwapOrder) {
         EXPECT_EQ(packet->mCode, 0);
         EXPECT_FALSE(packet->mBroken);
 
-        EXPECT_EQ(packet->mFrameSize, MTU - myEFPPacker->getType2Size());
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize(MTU - myEFPPacker->getType2Size());
+    mydata.resize(FRAME_SIZE);
 
     uint8_t streamID = 1;
     ElasticFrameMessages result = myEFPPacker->packAndSend(mydata, ElasticFrameContent::h264, 1001, 1, 0, streamID,

--- a/unitTests/UnitTest11.cpp
+++ b/unitTests/UnitTest11.cpp
@@ -12,6 +12,7 @@
 //This is testing the out of order head of line blocking mechanism
 //The result should be: deliver packet 1,2,4,5 even though we gave the unpacker them in order 5,4,2,1.
 TEST(UnitTest11, SendFivePacketsDeliverInReversedOrder) {
+    const size_t FRAME_SIZE = ((MTU - ElasticFrameProtocolSender::getType1Size()) * 5) + 12;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50,
                                                                                                                  20);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -57,12 +58,12 @@ TEST(UnitTest11, SendFivePacketsDeliverInReversedOrder) {
         EXPECT_EQ(packet->mCode, 0);
         EXPECT_FALSE(packet->mBroken);
 
-        EXPECT_EQ(packet->mFrameSize, ((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
         dataReceived++;
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+    mydata.resize(FRAME_SIZE);
 
     uint8_t streamID = 1;
     for (size_t packetNumber = 0; packetNumber < 5; packetNumber++) {

--- a/unitTests/UnitTest12.cpp
+++ b/unitTests/UnitTest12.cpp
@@ -12,6 +12,7 @@
 //This is testing the out of order head of line blocking mechanism
 //The result should be deliver packer 1,2,4,5 even though we gave the unpacker them in order 5,4,2,1.
 TEST(UnitTest12, SendFivePacketsDeliverInReversedOrderWithReversedFragmentOrder) {
+    const size_t FRAME_SIZE = ((MTU - ElasticFrameProtocolSender::getType1Size()) * 5) + 12;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(100,
                                                                                                                  40);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -57,12 +58,12 @@ TEST(UnitTest12, SendFivePacketsDeliverInReversedOrderWithReversedFragmentOrder)
         EXPECT_EQ(packet->mCode, 0);
         EXPECT_FALSE(packet->mBroken);
 
-        EXPECT_EQ(packet->mFrameSize, ((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
         dataReceived++;
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+    mydata.resize(FRAME_SIZE);
 
     uint8_t streamID = 1;
     for (size_t packetNumber = 0; packetNumber < 5; packetNumber++) {

--- a/unitTests/UnitTest13.cpp
+++ b/unitTests/UnitTest13.cpp
@@ -13,6 +13,7 @@
 //This is testing the out of order head of line blocking mechanism
 //The result should be deliver packer 1,2,4,5 even though we gave the unpacker them in order 5,4,2,1.
 TEST(UnitTest13, SendSuperFramesOfRandomSize) {
+    const size_t FRAME_SIZE = ((MTU - ElasticFrameProtocolSender::getType1Size()) * 5) + 12;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50,
                                                                                                                  20);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -35,7 +36,7 @@ TEST(UnitTest13, SendSuperFramesOfRandomSize) {
         EXPECT_EQ(packet->mCode, 0);
         EXPECT_FALSE(packet->mBroken);
 
-        EXPECT_EQ(packet->mFrameSize, ((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
 
         EXPECT_LE(receivedFrameNumber, 100000);
 
@@ -47,7 +48,7 @@ TEST(UnitTest13, SendSuperFramesOfRandomSize) {
     uint8_t streamID = 1;
     for (size_t packetNumber = 0; packetNumber < 100000; packetNumber++) {
         mydata.clear();
-        mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+        mydata.resize(FRAME_SIZE);
         ElasticFrameMessages result = myEFPPacker->packAndSend(mydata, ElasticFrameContent::h264, packetNumber + 1001,
                                                                packetNumber + 1, 0, streamID, NO_FLAGS);
         ASSERT_EQ(result, ElasticFrameMessages::noError);

--- a/unitTests/UnitTest14.cpp
+++ b/unitTests/UnitTest14.cpp
@@ -18,6 +18,7 @@ namespace {
 //Send 15 packets with embeddedPrivateData. Odd packet numbers will have two embedded private data fields. Also check for not broken and correct FourCC code.
 //The reminder of the packet is a vector. Check it's integrity
 TEST(UnitTest14, SendPrivateEmbeddedData) {
+    const size_t FRAME_SIZE = ((MTU - ElasticFrameProtocolSender::getType1Size()) * 5) + 12;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50,
                                                                                                                  20);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -71,7 +72,7 @@ TEST(UnitTest14, SendPrivateEmbeddedData) {
     uint8_t streamID = 1;
     for (size_t packetNumber = 0; packetNumber < 15; packetNumber++) {
         std::vector<uint8_t> mydata;
-        mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+        mydata.resize(FRAME_SIZE);
         std::generate(mydata.begin(), mydata.end(), [n = 0]() mutable { return n++; });
 
         PrivateData myPrivateData;

--- a/unitTests/UnitTest18.cpp
+++ b/unitTests/UnitTest18.cpp
@@ -9,6 +9,7 @@
 //UnitTest18
 //Using the optional lambda in the pack and send method
 TEST(UnitTest18, OptionalLambdaInPackAndSend) {
+    const size_t FRAME_SIZE = ((MTU - ElasticFrameProtocolSender::getType1Size()) * 5) + 12;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(100,
                                                                                                                  40);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -29,7 +30,7 @@ TEST(UnitTest18, OptionalLambdaInPackAndSend) {
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+    mydata.resize(FRAME_SIZE);
 
     uint8_t streamID = 1;
     for (int packetNumber = 0; packetNumber < 5; packetNumber++) {

--- a/unitTests/UnitTest2.cpp
+++ b/unitTests/UnitTest2.cpp
@@ -9,15 +9,19 @@
 //UnitTest2
 //Test sending a packet less than MTU + header - > Expected result is one type2 frame only sent and only one received
 TEST(UnitTest2, SendType2Frame) {
+    const size_t FRAME_SIZE = MTU - ElasticFrameProtocolSender::getType2Size();
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50,
                                                                                                                  20);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
     std::atomic<bool> dataReceived = false;
 
+    size_t dataSent = 0;
     myEFPPacker->sendCallback = [&](const std::vector<uint8_t> &subPacket, uint8_t lStreamID,
                                     ElasticFrameProtocolContext *pCTX) {
         ElasticFrameMessages status = myEFPReceiver->receiveFragment(subPacket, 0);
         EXPECT_EQ(status, ElasticFrameMessages::noError);
+        dataSent++;
+        EXPECT_LE(dataSent, 1);
     };
     myEFPReceiver->receiveCallback = [&](ElasticFrameProtocolReceiver::pFramePtr &packet,
                                          ElasticFrameProtocolContext *) {
@@ -25,11 +29,12 @@ TEST(UnitTest2, SendType2Frame) {
         EXPECT_EQ(packet->mCode, 2);
         EXPECT_FALSE(packet->mBroken);
         EXPECT_EQ(packet->mDataContent, ElasticFrameContentNamespace::adts);
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
         dataReceived = true;
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize(MTU - myEFPPacker->getType2Size());
+    mydata.resize(FRAME_SIZE);
 
     uint8_t streamID = 1;
     ElasticFrameMessages result = myEFPPacker->packAndSend(mydata, ElasticFrameContent::adts, 1001, 1, 2, streamID,

--- a/unitTests/UnitTest20.cpp
+++ b/unitTests/UnitTest20.cpp
@@ -10,6 +10,7 @@
 //Test basic run to completion
 //Test sending a packet of MTU-headertype1+1 > result should be one frame type1 and a frame type 2, MTU+1 at the receiver
 TEST(UnitTest20, RunToCompletion) {
+    const size_t FRAME_SIZE = (MTU - ElasticFrameProtocolSender::getType1Size()) + 1;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50, 20,
                                                                                                                  nullptr,
                                                                                                                  ElasticFrameProtocolReceiver::EFPReceiverMode::RUN_TO_COMPLETION);
@@ -44,12 +45,12 @@ TEST(UnitTest20, RunToCompletion) {
         EXPECT_EQ(packet->mPts, 1001);
         EXPECT_EQ(packet->mCode, 2);
         EXPECT_FALSE(packet->mBroken);
-        EXPECT_EQ(packet->mFrameSize, (MTU - myEFPPacker->getType1Size()) + 1);
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
         dataReceived++;
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize((MTU - myEFPPacker->getType1Size()) + 1);
+    mydata.resize(FRAME_SIZE);
 
     uint8_t streamID = 4;
     ElasticFrameMessages result = myEFPPacker->packAndSend(mydata, ElasticFrameContent::adts, 1001, 1, 2, streamID,

--- a/unitTests/UnitTest21.cpp
+++ b/unitTests/UnitTest21.cpp
@@ -8,6 +8,7 @@
 //UnitTest21
 //Zero copy test
 TEST(UnitTest21, ZeroCopySend) {
+    const size_t FRAME_SIZE = ((MTU - ElasticFrameProtocolSender::getType1Size()) * 5) + 12;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(100,
                                                                                                                  40);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -22,7 +23,7 @@ TEST(UnitTest21, ZeroCopySend) {
         EXPECT_EQ(packet->mCode, 0);
         EXPECT_FALSE(packet->mBroken);
 
-        EXPECT_EQ(packet->mFrameSize, ((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
 
         uint8_t vectorChecker = 0;
         for (size_t x = 0; x < packet->mFrameSize; x++) {
@@ -35,7 +36,7 @@ TEST(UnitTest21, ZeroCopySend) {
     uint8_t streamID = 1;
     for (size_t packetNumber = 0; packetNumber < 5; packetNumber++) {
         std::vector<uint8_t> mydata;
-        mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12 + 100);
+        mydata.resize(FRAME_SIZE + 100);
         std::generate(mydata.begin() + 100, mydata.end(), [n = 0]() mutable { return n++; });
 
         auto sendCallback = [&](const uint8_t *lData, size_t lSize) {

--- a/unitTests/UnitTest22.cpp
+++ b/unitTests/UnitTest22.cpp
@@ -19,6 +19,7 @@
 //Expected result is that all frames should be delivered in order (EFP is set to HOL-mode) but mark frame 2 as broken
 //When passing fragment 5 again (meaning sending late fragments) EFP should respond with too old.
 TEST(UnitTest22, HeadOfLineBlocking) {
+    const size_t FRAME_SIZE = ((MTU - ElasticFrameProtocolSender::getType1Size()) * 5) + 12;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(20, 20,
                                                                                                                  nullptr,
                                                                                                                  ElasticFrameProtocolReceiver::EFPReceiverMode::RUN_TO_COMPLETION);
@@ -70,7 +71,7 @@ TEST(UnitTest22, HeadOfLineBlocking) {
             EXPECT_FALSE(packet->mBroken);
 
             uint8_t vectorChecker = 0;
-            for (size_t x = 0; x < ((MTU - myEFPPacker->getType1Size()) * 5 + 12); x++) {
+            for (size_t x = 0; x < FRAME_SIZE; x++) {
                 EXPECT_EQ(packet->pFrameData[x], vectorChecker++);
             }
         }
@@ -79,7 +80,7 @@ TEST(UnitTest22, HeadOfLineBlocking) {
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+    mydata.resize(FRAME_SIZE);
     std::generate(mydata.begin(), mydata.end(), [n = 0]() mutable { return n++; });
 
     uint8_t streamID = 1;

--- a/unitTests/UnitTest23.cpp
+++ b/unitTests/UnitTest23.cpp
@@ -7,9 +7,9 @@
 
 
 // UnitTest23
-// Test sending 10 packets, with 5 frame type 1 + 1 frame type 2
+// Test sending 10 packets, each being split into six EFP fragments, five of type 1 and one of type 2
 // Drop packet 4 and 5, and deliver the rest in reversed order
-// Check that we can see that we lost two superframes in the receiver when we receive the last packet
+// Check that we can see that we lost two packets/superframes in the receiver when we receive the last packet
 TEST(UnitTest23, SendFivePacketsDeliverInReversedOrderWithReversedFragmentOrder) {
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(100,
                                                                                                                  40);

--- a/unitTests/UnitTest23.cpp
+++ b/unitTests/UnitTest23.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "ElasticFrameProtocol.h"
+#include "UnitTestHelpers.h"
+
+
+// UnitTest23
+// Test sending 10 packets, with 5 frame type 1 + 1 frame type 2
+// Drop packet 4 and 5, and deliver the rest in reversed order
+// Check that we can see that we lost two superframes in the receiver when we receive the last packet
+TEST(UnitTest23, SendFivePacketsDeliverInReversedOrderWithReversedFragmentOrder) {
+    std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(100,
+                                                                                                                 40);
+    std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
+    std::atomic<size_t> dataReceived = 0;
+
+    size_t sentSuperFrameNumber = 0;
+    std::vector<std::vector<uint8_t>> keptBackFragments;
+    std::vector<std::vector<std::vector<uint8_t>>> keptBackSuperFrames;
+    myEFPPacker->sendCallback = [&](const std::vector<uint8_t> &subPacket, uint8_t lStreamID,
+                                    ElasticFrameProtocolContext *pCTX) {
+        if (subPacket[0] == 2) {
+            sentSuperFrameNumber++;
+            keptBackFragments.push_back(subPacket);
+            keptBackSuperFrames.push_back(keptBackFragments);
+            if (sentSuperFrameNumber == 10) {
+                for (size_t item = keptBackSuperFrames.size(); item > 0; item--) {
+                    if (item == 4 || item == 5) {
+                        continue; // Drop packet 4 and 5
+                    }
+                    std::vector<std::vector<uint8_t>> superFrame = keptBackSuperFrames[item - 1];
+                    for (size_t fragment = superFrame.size(); fragment > 0; fragment--) {
+                        ElasticFrameMessages info = myEFPReceiver->receiveFragment(superFrame[fragment - 1], 0);
+                        EXPECT_EQ(info, ElasticFrameMessages::noError);
+                    }
+                }
+            }
+            keptBackFragments.clear();
+            return;
+        }
+        keptBackFragments.push_back(subPacket);
+    };
+
+    size_t receivedFrameNumber = 0;
+    int64_t nextExpectedPts = 1001;
+    uint16_t lastReceivedSuperFrame = 0;
+    myEFPReceiver->receiveCallback = [&](ElasticFrameProtocolReceiver::pFramePtr &packet,
+                                         ElasticFrameProtocolContext *) {
+        std::cout << "Receiving frame " << packet->mPts << std::endl;
+        receivedFrameNumber++;
+        EXPECT_EQ(packet->mPts, nextExpectedPts);
+        // Expect pts 1004 and 1005 to be missing
+        nextExpectedPts += (nextExpectedPts == 1003 ? 3 : 1);
+
+        EXPECT_EQ(packet->mStreamID, 1);
+        EXPECT_EQ(packet->mCode, 0);
+        EXPECT_FALSE(packet->mBroken);
+
+        EXPECT_EQ(packet->mFrameSize, ((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+
+        if (packet->mPts == 1006) {
+            // Check that we know we lost 2 super frames here
+            EXPECT_EQ(lastReceivedSuperFrame + 3, packet->mSuperFrameNo);
+        } else if (packet->mPts != 1001) {
+            EXPECT_EQ(lastReceivedSuperFrame + 1, packet->mSuperFrameNo);
+        }
+        lastReceivedSuperFrame = packet->mSuperFrameNo;
+
+        dataReceived++;
+    };
+
+    std::vector<uint8_t> mydata;
+    mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+
+    uint8_t streamID = 1;
+    for (size_t packetNumber = 0; packetNumber < 10; packetNumber++) {
+        ElasticFrameMessages result = myEFPPacker->packAndSend(mydata, ElasticFrameContent::h264, packetNumber + 1001,
+                                                               packetNumber + 1, 0,
+                                                               streamID, NO_FLAGS);
+        ASSERT_EQ(result, ElasticFrameMessages::noError);
+    }
+
+    EXPECT_TRUE(UnitTestHelpers::waitUntil([&]() {
+        return dataReceived.load() == 8;
+    }, std::chrono::milliseconds(500)));
+}

--- a/unitTests/UnitTest23.cpp
+++ b/unitTests/UnitTest23.cpp
@@ -11,6 +11,7 @@
 // Drop packet 4 and 5, and deliver the rest in reversed order
 // Check that we can see that we lost two packets/superframes in the receiver when we receive the last packet
 TEST(UnitTest23, SendFivePacketsDeliverInReversedOrderWithReversedFragmentOrder) {
+    const size_t FRAME_SIZE = ((MTU - ElasticFrameProtocolSender::getType1Size()) * 5) + 12;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(100,
                                                                                                                  40);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -58,7 +59,7 @@ TEST(UnitTest23, SendFivePacketsDeliverInReversedOrderWithReversedFragmentOrder)
         EXPECT_EQ(packet->mCode, 0);
         EXPECT_FALSE(packet->mBroken);
 
-        EXPECT_EQ(packet->mFrameSize, ((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
 
         if (packet->mPts == 1006) {
             // Check that we know we lost 2 super frames here
@@ -72,7 +73,7 @@ TEST(UnitTest23, SendFivePacketsDeliverInReversedOrderWithReversedFragmentOrder)
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+    mydata.resize(FRAME_SIZE);
 
     uint8_t streamID = 1;
     for (size_t packetNumber = 0; packetNumber < 10; packetNumber++) {

--- a/unitTests/UnitTest23.cpp
+++ b/unitTests/UnitTest23.cpp
@@ -49,7 +49,6 @@ TEST(UnitTest23, SendFivePacketsDeliverInReversedOrderWithReversedFragmentOrder)
     uint16_t lastReceivedSuperFrame = 0;
     myEFPReceiver->receiveCallback = [&](ElasticFrameProtocolReceiver::pFramePtr &packet,
                                          ElasticFrameProtocolContext *) {
-        std::cout << "Receiving frame " << packet->mPts << std::endl;
         receivedFrameNumber++;
         EXPECT_EQ(packet->mPts, nextExpectedPts);
         // Expect pts 1004 and 1005 to be missing

--- a/unitTests/UnitTest3.cpp
+++ b/unitTests/UnitTest3.cpp
@@ -9,6 +9,7 @@
 //UnitTest3
 //Test sending 1 byte packet of value 0xaa and receiving it at the EFP receiver.
 TEST(UnitTest3, SendOneBytePacket) {
+    const size_t FRAME_SIZE = 1;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50,
                                                                                                                  20);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -25,12 +26,13 @@ TEST(UnitTest3, SendOneBytePacket) {
         EXPECT_EQ(packet->mCode, 2);
         EXPECT_FALSE(packet->mBroken);
         EXPECT_EQ(packet->mDataContent, ElasticFrameContentNamespace::adts);
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
         EXPECT_EQ(packet->pFrameData[0], 0xaa);
         dataReceived = true;
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize(1);
+    mydata.resize(FRAME_SIZE);
     mydata[0] = 0xaa;
 
     uint8_t streamID = 1;

--- a/unitTests/UnitTest4.cpp
+++ b/unitTests/UnitTest4.cpp
@@ -9,6 +9,7 @@
 //UnitTest4
 //Test sending a packet of MTU-HeaderType1+1 > result should be one frame type1 and a frame type 2, MTU+1 at the receiver
 TEST(UnitTest4, SendPacketFrameType1AndFrameType2) {
+    const size_t FRAME_SIZE = (MTU - ElasticFrameProtocolSender::getType1Size()) + 1;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50,
                                                                                                                  20);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -38,12 +39,12 @@ TEST(UnitTest4, SendPacketFrameType1AndFrameType2) {
         EXPECT_EQ(packet->mPts, 1001);
         EXPECT_EQ(packet->mCode, 2);
         EXPECT_FALSE(packet->mBroken);
-        EXPECT_EQ(packet->mFrameSize, (MTU - myEFPPacker->getType1Size()) + 1);
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
         dataReceived = true;
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize((MTU - myEFPPacker->getType1Size()) + 1);
+    mydata.resize(FRAME_SIZE);
 
     uint8_t streamID = 4;
     ElasticFrameMessages result = myEFPPacker->packAndSend(mydata, ElasticFrameContent::adts, 1001, 1, 2, streamID,

--- a/unitTests/UnitTest5.cpp
+++ b/unitTests/UnitTest5.cpp
@@ -9,6 +9,7 @@
 //UnitTest5
 //Test sending a packet of MTU*5+MTU/2 containing a linear vector -> the result should be a packet with that size containing a linear vector.
 TEST(UnitTest5, SendLinearVectorOverMultipleFragments) {
+    const size_t FRAME_SIZE = (MTU * 5) + (MTU / 2);
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50,
                                                                                                                  20);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -26,7 +27,7 @@ TEST(UnitTest5, SendLinearVectorOverMultipleFragments) {
         EXPECT_EQ(packet->mPts, 1001);
         EXPECT_EQ(packet->mCode, 2);
         EXPECT_FALSE(packet->mBroken);
-        EXPECT_EQ(packet->mFrameSize, ((MTU * 5) + (MTU / 2)));
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
 
         uint8_t vectorChecker = 0;
         for (size_t x = 0; x < packet->mFrameSize; x++) {
@@ -36,7 +37,7 @@ TEST(UnitTest5, SendLinearVectorOverMultipleFragments) {
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize((MTU * 5) + (MTU / 2));
+    mydata.resize(FRAME_SIZE);
     std::generate(mydata.begin(), mydata.end(), [n = 0]() mutable { return n++; });
 
     uint8_t streamID = 1;

--- a/unitTests/UnitTest7.cpp
+++ b/unitTests/UnitTest7.cpp
@@ -10,6 +10,7 @@
 //Test sending packets, 5 type 1 + 1 type 2.. Reorder type1 packet 3 and 2 so the delivery order is 1 3 2 4 5 6
 //then check for correct length and correct vector in the payload
 TEST(UnitTest7, SendLinearVectorAndSwapFragmentOrder) {
+    const size_t FRAME_SIZE = ((MTU - ElasticFrameProtocolSender::getType1Size()) * 5) + 12;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50,
                                                                                                                  20);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -46,7 +47,7 @@ TEST(UnitTest7, SendLinearVectorAndSwapFragmentOrder) {
         EXPECT_EQ(packet->mCode, 2);
         EXPECT_FALSE(packet->mBroken);
 
-        EXPECT_EQ(packet->mFrameSize, (((MTU - myEFPPacker->getType1Size()) * 5) + 12));
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
 
         uint8_t vectorChecker = 0;
         for (size_t x = 0; x < packet->mFrameSize; x++) {
@@ -56,7 +57,7 @@ TEST(UnitTest7, SendLinearVectorAndSwapFragmentOrder) {
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+    mydata.resize(FRAME_SIZE);
     std::generate(mydata.begin(), mydata.end(), [n = 0]() mutable { return n++; });
 
     uint8_t streamID = 8;

--- a/unitTests/UnitTest8.cpp
+++ b/unitTests/UnitTest8.cpp
@@ -9,6 +9,7 @@
 //UnitTest8
 //Test sending packets, 5 type 1 + 1 type 2.. Send the type2 packet first to the unpacker and send the type1 packets out of order
 TEST(UnitTest8, SendLinearVectorReceiverType2FragmentFirst) {
+    const size_t FRAME_SIZE = ((MTU - ElasticFrameProtocolSender::getType1Size()) * 5) + 12;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50,
                                                                                                                  20);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -42,7 +43,7 @@ TEST(UnitTest8, SendLinearVectorReceiverType2FragmentFirst) {
         EXPECT_EQ(packet->mCode, 2);
         EXPECT_FALSE(packet->mBroken);
 
-        EXPECT_EQ(packet->mFrameSize, (((MTU - myEFPPacker->getType1Size()) * 5) + 12));
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE);
 
         uint8_t vectorChecker = 0;
         for (size_t x = 0; x < packet->mFrameSize; x++) {
@@ -52,7 +53,7 @@ TEST(UnitTest8, SendLinearVectorReceiverType2FragmentFirst) {
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+    mydata.resize(FRAME_SIZE);
     std::generate(mydata.begin(), mydata.end(), [n = 0]() mutable { return n++; });
 
     uint8_t streamID = 8;

--- a/unitTests/UnitTest9.cpp
+++ b/unitTests/UnitTest9.cpp
@@ -10,6 +10,7 @@
 //Test sending packets, 5 type 1 + 1 type 2.. Drop the type 2 packet.
 //broken should be set, the PTS and code should be set to the illegal value and the vector should be linear for 5 times MTU - myEFPPacker.getType1Size()
 TEST(UnitTest9, SendLinearVectorDropType2Packet) {
+    const size_t FRAME_SIZE = ((MTU - ElasticFrameProtocolSender::getType1Size()) * 5) + 12;
     std::unique_ptr<ElasticFrameProtocolReceiver> myEFPReceiver = std::make_unique<ElasticFrameProtocolReceiver>(50,
                                                                                                                  20);
     std::unique_ptr<ElasticFrameProtocolSender> myEFPPacker = std::make_unique<ElasticFrameProtocolSender>(MTU);
@@ -31,17 +32,17 @@ TEST(UnitTest9, SendLinearVectorDropType2Packet) {
         EXPECT_EQ(packet->mCode, UINT32_MAX);
         EXPECT_TRUE(packet->mBroken);
 
-        EXPECT_EQ(packet->mFrameSize, ((MTU - myEFPPacker->getType1Size()) * 5));
+        EXPECT_EQ(packet->mFrameSize, FRAME_SIZE - 12); // Last 12 bytes should be lost with the type 2 fragment
 
         uint8_t vectorChecker = 0;
-        for (size_t x = 0; x < ((MTU - myEFPPacker->getType1Size()) * 5); x++) {
+        for (size_t x = 0; x < packet->mFrameSize; x++) {
             EXPECT_EQ(packet->pFrameData[x], vectorChecker++);
         }
         dataReceived = true;
     };
 
     std::vector<uint8_t> mydata;
-    mydata.resize(((MTU - myEFPPacker->getType1Size()) * 5) + 12);
+    mydata.resize(FRAME_SIZE);
     std::generate(mydata.begin(), mydata.end(), [n = 0]() mutable { return n++; });
 
     uint8_t streamID = 1;


### PR DESCRIPTION
Include the super frame number in the callback to the EFP receiver, which will make it possible to count the number of super frames that has been lost when in Head-of-line blocking mode. This counter is only 16 bits, so a maximum of 65535 lost super frames can be detected. 